### PR TITLE
Add zstandard pip dependency

### DIFF
--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -37,6 +37,7 @@
         "python3-packaging.json",
         "python3-steam.json",
         "python3-PyYAML.json",
+        "python3-zstandard.json",
         {
             "name": "pyside6",
             "buildsystem": "simple",

--- a/python3-zstandard.json
+++ b/python3-zstandard.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-zstandard",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"zstandard\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/9a/50/1b7f7f710c0dfc1019ec4c7295f67855722c342af82f3132664ca6dc1c07/zstandard-0.19.0.tar.gz",
+            "sha256": "31d12fcd942dd8dbf52ca5f6b1bbe287f44e5d551a081a983ff3ea2082867863"
+        }
+    ]
+}


### PR DESCRIPTION
The ctmod `vkd3d-proton` requires the `zstandard` pip dependency: https://pypi.org/project/zstandard/

Adds `python3-zstandard.json` with the zstandard dependency.

See https://github.com/DavidoTek/ProtonUp-Qt/issues/169