### PR TITLE
Heroic Flatpak: Add GamesConfig to filesystem

### DIFF
--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -25,6 +25,7 @@
         "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic/tools",
         "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic/sideload_apps",
         "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic/gog_store",
+        "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig",
         "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/legendary",
         "--filesystem=~/stl:create",
         "--filesystem=~/.config",


### PR DESCRIPTION
The path to `~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig` was missing from the filesystem permissions, so Heroic couldn't find the Wine compatibility information. This meant `wine_info` was always blank on each `HeroicGame` and so the platform would always default to `Native`.

This is fixed in this PR by adding the mentioned filesystem path :-) I verified the names are correct as well by comparing running from source.

Before:
![image](https://github.com/flathub/net.davidotek.pupgui2/assets/7917345/914fc752-0040-4610-a139-9286b843776c)

After (by adding the path manually using Flatseal):
![image](https://github.com/flathub/net.davidotek.pupgui2/assets/7917345/5530df14-5bf3-4a0f-ab63-069aea86c05f)

<hr>

This only affects Heroic Flatpak. Other builds such as Flatpak/Package Manager are unaffected because they write to `~/.config`, and we have full read access here already.