### PR TITLE
Heroic: Addd store_cache for accessing Amazon Games list

### DIFF
--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -26,6 +26,7 @@
         "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic/sideload_apps",
         "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic/gog_store",
         "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig",
+        "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic/store_cache",
         "--filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/legendary",
         "--filesystem=~/stl:create",
         "--filesystem=~/.config",


### PR DESCRIPTION
Adds the Heroic `store_cache` path to the Flatpak directory permissions.

Not strictly necessary just yet, but will be required in future to display Amazon Games in the Games List following DavidoTek/ProtonUp-Qt#271 :-)