### PR TITLE
Bump KDE SDK to 6.5

### DIFF
--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.davidotek.pupgui2",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.4",
+    "runtime-version": "6.5",
     "sdk": "org.kde.Sdk",
     "command": "net.davidotek.pupgui2",
     "finish-args": [

--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -58,8 +58,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/51/23/44fe28b2b7ee64cb53b72ab3b559cb41986a218e98d1fe298bedf903898e/PySide6_Essentials-6.4.3-cp37-abi3-manylinux_2_28_x86_64.whl",
-                    "sha256": "7983cf2152dfebf3c2d0767d12e452c4bd0809aa53777fef949a7ff4b0ef8a49"
+                    "url": "https://files.pythonhosted.org/packages/d0/de/9a089e91c2e0fe4f122218bba4f9dbde46338659f412739bd9db1ed9df4f/PySide6_Essentials-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl",
+                    "sha256": "1620e82b38714a1570b142c01694d0415a25526517b24620ff9b00c9f76cfca9"
                 }
             ],
             "modules": [
@@ -72,8 +72,8 @@
                     "sources": [
                         {
                             "type": "file",
-                            "url": "https://files.pythonhosted.org/packages/f9/52/4461d3d5cabfaeb56562d72a4b1013ecf1fd7be2ef7bebdc7649d56ab1b8/shiboken6-6.4.3-cp37-abi3-manylinux_2_28_x86_64.whl",
-                            "sha256": "74570273004d2e481e55618150dfaee7ae253027b438066e216b339fae1e999a"
+                            "url": "https://files.pythonhosted.org/packages/55/44/d8c366dd4f069166ab9890acb44d004c5e6122714e44c169273dcbbca897/shiboken6-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl",
+                            "sha256": "3fbc35ff3c19e7d39433671bfc1be3d7fa9d071bfdd0ffe1c2a4d27acd6cf6a5"
                         }
                     ]
                 }


### PR DESCRIPTION
Resolves DavidoTek/ProtonUp-Qt#283.

KDE SDK 6.4 was [EOL'd a couple of days ago](https://invent.kde.org/packaging/flatpak-kde-runtime/-/merge_requests/140). This bumps the KDE SDK to use the latest 6.5.

Have not tested to see if this has any potential impact, will check once the Flathub bot builds a version to test out :-)