### PR TITLE
replace x11 socket with fallback-x11

### DIFF
--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -7,7 +7,7 @@
     "finish-args": [
         "--share=ipc",
         "--share=network",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--filesystem=~/.steam",
         "--filesystem=~/.local/share/Steam",


### PR DESCRIPTION
Resolves DavidoTek/ProtonUp-Qt#284.

Flathub now lists security/permission related information about Flatpaks. ProtonUp-Qt is flagged as "potentially unsafe" and one of the reasons for this is "using a legacy windowing system". This is caused by ProtonUp-Qt enabling the `x11` socket by default, instead of using `fallback-x11`.

ProtonUp-Qt has *a lot* of things flagging it at time of writing, most of which we can't do much about: accessing specific files for installing compatibility tools to specific folders, "acquire arbitrary permissions" which is caused by some specific file permissions, and accessing devices for gamepad support. This legacy windowing system warning, however, is something we can hopefully resolve, provided issues related to Qt are fixed.

Previously, this had some issues due to a regression with Qt6, and was removed (0a4fd4eeb89ebd519c640fd124c1e731b66398ec). We can use this PR to test. I tested myself with `fallback-x11` enabled and `x11` disabled using Flatseal to do so, and tested the native Wayland support and forcing X11 support with `QT_QPA_PLATFORM="xcb"`. Everything appeared to work fine in testing. I had this enabled for a while and actually completely forgot again, and it has worked with my general usage of ProtonUp-Qt that I didn't even realise this option was enabled. I confirmed when X11 was in use with `xeyes` and also I could tell because Xwayland applications are blurry on my scaled display, whereas Wayland applications are crisp.

Testing was conducted with ProtonUp-Qt Flatpak from Flathub, and primarily tested with the PySide6 6.5.2 bump, which fixed a *all* of window artifacting problems on scaled displays, so I would hope that if any issues were still present with older PySide6 versions, that they would now be fixed.