### PR TITLE
Update runtime to 24.08, update components, add x-checker-data

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "require-important-update": true
 }

--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -69,7 +69,14 @@
                 {
                     "type": "git",
                     "url": "https://github.com/DavidoTek/ProtonUp-Qt",
-                    "commit": "bb3ba5afe05521a1b1c6e4c4b3c3a56e5de5c566"
+                    "tag": "v2.11.1",
+                    "commit": "bb3ba5afe05521a1b1c6e4c4b3c3a56e5de5c566",
+                    "x-checker-data":
+                        {
+                            "type":"git",
+                            "tag-pattern": "^v([\\d.]+)$",
+                            "is-important": true
+                        }
                 }
             ]
         },

--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -3,12 +3,7 @@
     "runtime": "org.kde.Platform",
     "runtime-version": "6.8",
     "sdk": "org.kde.Sdk",
-    "base": "io.qt.PySide.BaseApp",
-    "base-version": "6.8",
     "command": "net.davidotek.pupgui2",
-    "cleanup-commands": [
-        "/app/cleanup-BaseApp.sh"
-    ],
     "finish-args": [
         "--share=ipc",
         "--share=network",
@@ -51,6 +46,40 @@
         "python3-steam.json",
         "python3-PyYAML.json",
         "python3-zstandard.json",
+        {
+            "name": "pyside6",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} pyside6_essentials --no-build-isolation",
+                "rm -rf ${FLATPAK_DEST}/bin/pyside6-{assistant,designer,linguist,lrelease,lupdate,qmllint}",
+                "rm -rf ${FLATPAK_DEST}/lib/python3.*/site-packages/PySide6/{assistant,designer,linguist,lrelease,lupdate,qmllint}",
+                "rm -rf ${FLATPAK_DEST}/lib/python3.*/site-packages/PySide6/{examples,Qt/qml,Qt/resources,Qt/translations/qtwebengine_locales}",
+                "rm -rf ${FLATPAK_DEST}/lib/python3.*/site-packages/PySide6/Qt/lib"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d9/cd/2877d399e1304589fada703a45b6d496247257a9cc318b52976056fed9a0/PySide6_Essentials-6.8.1.1-cp39-abi3-manylinux_2_28_x86_64.whl",
+                    "sha256": "62b64842a91114c224c41eeb6a8c8f255ba60268bc5ac19724f944d60e2277c6"
+                }
+            ],
+            "modules": [
+                {
+                    "name": "shiboken6",
+                    "buildsystem": "simple",
+                    "build-commands": [
+                        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} shiboken6 --no-build-isolation"
+                    ],
+                    "sources": [
+                        {
+                            "type": "file",
+                            "url": "https://files.pythonhosted.org/packages/bc/a2/27586f87b2364a8ec085083a367e494698b15a6ba9065d9d984ebbc10179/shiboken6-6.8.1.1-cp39-abi3-manylinux_2_28_x86_64.whl",
+                            "sha256": "d672df0f29dc5f44de7205c1acae4d0471ba8371bb1d68fdacbf1686f4d22a96"
+                        }
+                    ]
+                }
+            ]
+        },
         {
             "name": "pupgui2",
             "buildsystem": "simple",

--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -3,7 +3,7 @@
     "runtime": "org.kde.Platform",
     "runtime-version": "6.8",
     "sdk": "org.kde.Sdk",
-    "base-app": "io.qt.PySide.BaseApp",
+    "base": "io.qt.PySide.BaseApp",
     "base-version": "6.8",
     "command": "net.davidotek.pupgui2",
     "cleanup-commands": [

--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -9,11 +9,6 @@
     "cleanup-commands": [
         "/app/cleanup-BaseApp.sh"
     ],
-    "build-options": {
-        "env": {
-            "BASEAPP_REMOVE_WEBENGINE":"1"
-        }
-    },
     "finish-args": [
         "--share=ipc",
         "--share=network",

--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -1,9 +1,19 @@
 {
     "app-id": "net.davidotek.pupgui2",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.7",
+    "runtime-version": "6.8",
     "sdk": "org.kde.Sdk",
+    "base-app": "io.qt.PySide.BaseApp",
+    "base-version": "6.8",
     "command": "net.davidotek.pupgui2",
+    "cleanup-commands": [
+        "/app/cleanup-BaseApp.sh"
+    ],
+    "build-options": {
+        "env": {
+            "BASEAPP_REMOVE_WEBENGINE":"1"
+        }
+    },
     "finish-args": [
         "--share=ipc",
         "--share=network",
@@ -46,40 +56,6 @@
         "python3-steam.json",
         "python3-PyYAML.json",
         "python3-zstandard.json",
-        {
-            "name": "pyside6",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} pyside6_essentials --no-build-isolation",
-                "rm -rf ${FLATPAK_DEST}/bin/pyside6-{assistant,designer,linguist,lrelease,lupdate,qmllint}",
-                "rm -rf ${FLATPAK_DEST}/lib/python3.*/site-packages/PySide6/{assistant,designer,linguist,lrelease,lupdate,qmllint}",
-                "rm -rf ${FLATPAK_DEST}/lib/python3.*/site-packages/PySide6/{examples,Qt/qml,Qt/resources,Qt/translations/qtwebengine_locales}",
-                "rm -rf ${FLATPAK_DEST}/lib/python3.*/site-packages/PySide6/Qt/lib"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d8/f7/7a8a0c3a87fc9a898a521ae34aea5806f71f7bef1a0e032a6d954550fcea/PySide6_Essentials-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl",
-                    "sha256": "e013238fe40596b804068e34ac173514943a41bf8e5fbb4edfc7c30b00431bd5"
-                }
-            ],
-            "modules": [
-                {
-                    "name": "shiboken6",
-                    "buildsystem": "simple",
-                    "build-commands": [
-                        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} shiboken6 --no-build-isolation"
-                    ],
-                    "sources": [
-                        {
-                            "type": "file",
-                            "url": "https://files.pythonhosted.org/packages/6a/05/a2f348685041495be25709f85ca30d9f79fdc4f3bcd4f8da8b980b1de071/shiboken6-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl",
-                            "sha256": "7887ba7ecfddb09ee9966325c1e229a17f3f444b0257b77cb7838792287d3e05"
-                        }
-                    ]
-                }
-            ]
-        },
         {
             "name": "pupgui2",
             "buildsystem": "simple",

--- a/python3-PyYAML.json
+++ b/python3-PyYAML.json
@@ -8,7 +8,11 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz",
-            "sha256": "d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"
+            "sha256": "d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "pyyaml"
+            }
         }
     ]
 }

--- a/python3-PyYAML.json
+++ b/python3-PyYAML.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz",
-            "sha256": "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"
+            "url": "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz",
+            "sha256": "d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"
         }
     ]
 }

--- a/python3-inputs.json
+++ b/python3-inputs.json
@@ -8,7 +8,12 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/d0/94/040a0d9c81f018c39bd887b7b825013b024deb0a6c795f9524797e2cd41b/inputs-0.5-py2.py3-none-any.whl",
-            "sha256": "13f894564e52134cf1e3862b1811da034875eb1f2b62e6021e3776e9669a96ec"
+            "sha256": "13f894564e52134cf1e3862b1811da034875eb1f2b62e6021e3776e9669a96ec",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "inputs",
+                "packagetype": "bdist_wheel"
+            }
         }
     ]
 }

--- a/python3-packaging.json
+++ b/python3-packaging.json
@@ -8,7 +8,12 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl",
-            "sha256": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"
+            "sha256": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "packaging",
+                "packagetype": "bdist_wheel"
+            }
         }
     ]
 }

--- a/python3-packaging.json
+++ b/python3-packaging.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl",
-            "sha256": "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+            "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl",
+            "sha256": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"
         }
     ]
 }

--- a/python3-pyxdg.json
+++ b/python3-pyxdg.json
@@ -8,7 +8,12 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/e5/8d/cf41b66a8110670e3ad03dab9b759704eeed07fa96e90fdc0357b2ba70e2/pyxdg-0.28-py2.py3-none-any.whl",
-            "sha256": "bdaf595999a0178ecea4052b7f4195569c1ff4d344567bccdc12dfdf02d545ab"
+            "sha256": "bdaf595999a0178ecea4052b7f4195569c1ff4d344567bccdc12dfdf02d545ab",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "pyxdg",
+                "packagetype": "bdist_wheel"
+            }
         }
     ]
 }

--- a/python3-requests.json
+++ b/python3-requests.json
@@ -7,18 +7,18 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/1c/d5/c84e1a17bf61d4df64ca866a1c9a913874b4e9bdc131ec689a0ad013fb36/certifi-2024.7.4-py3-none-any.whl",
-            "sha256": "c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
+            "url": "https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl",
+            "sha256": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
-            "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+            "url": "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl",
+            "sha256": "d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
-            "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
+            "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
+            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
         },
         {
             "type": "file",
@@ -27,8 +27,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ca/1c/89ffc63a9605b583d5df2be791a27bc1a42b7c32bab68d3c8f2f73a98cd4/urllib3-2.2.2-py3-none-any.whl",
-            "sha256": "a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"
+            "url": "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl",
+            "sha256": "1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"
         }
     ]
 }

--- a/python3-requests.json
+++ b/python3-requests.json
@@ -8,27 +8,52 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl",
-            "sha256": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"
+            "sha256": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "certifi",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl",
-            "sha256": "d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85"
+            "sha256": "d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "charset_normalizer",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
-            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "idna",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl",
-            "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
+            "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "requests",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl",
-            "sha256": "1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"
+            "sha256": "1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "urllib3",
+                "packagetype": "bdist_wheel"
+            }
         }
     ]
 }

--- a/python3-steam.json
+++ b/python3-steam.json
@@ -39,7 +39,7 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl",
             "sha256": "1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"
-        }
+        },
         {
             "type": "git",
             "url": "https://github.com/solsticegamestudios/steam",

--- a/python3-steam.json
+++ b/python3-steam.json
@@ -8,43 +8,81 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl",
-            "sha256": "02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292"
+            "sha256": "02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "cachetools",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl",
-            "sha256": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"
+            "sha256": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "certifi",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl",
-            "sha256": "d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85"
+            "sha256": "d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "charset_normalizer",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
-            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "idna",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/11/dc/e66551683ade663b5f07d7b3bc46434bf703491dbd22ee12d1f979ca828f/pycryptodomex-3.21.0.tar.gz",
-            "sha256": "222d0bd05381dd25c32dd6065c071ebf084212ab79bab4599ba9e6a3e0009e6c"
+            "sha256": "222d0bd05381dd25c32dd6065c071ebf084212ab79bab4599ba9e6a3e0009e6c",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "pycryptodomex"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl",
-            "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
+            "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "requests",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl",
-            "sha256": "1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"
+            "sha256": "1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "urllib3",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "git",
             "url": "https://github.com/solsticegamestudios/steam",
             "tag": "v1.6.1",
-            "commit": "c3f78074117691ef0ddf9a9020879eb5a426e090"
+            "commit": "c3f78074117691ef0ddf9a9020879eb5a426e090",
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^v([\\d.]+)$"
+            }
         }
     ]
 }

--- a/python3-steam.json
+++ b/python3-steam.json
@@ -12,23 +12,23 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/1c/d5/c84e1a17bf61d4df64ca866a1c9a913874b4e9bdc131ec689a0ad013fb36/certifi-2024.7.4-py3-none-any.whl",
-            "sha256": "c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
+            "url": "https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl",
+            "sha256": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
-            "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+            "url": "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl",
+            "sha256": "d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
-            "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
+            "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
+            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/31/a4/b03a16637574312c1b54c55aedeed8a4cb7d101d44058d46a0e5706c63e1/pycryptodomex-3.20.0.tar.gz",
-            "sha256": "7a710b79baddd65b806402e14766c721aee8fb83381769c27920f26476276c1e"
+            "url": "https://files.pythonhosted.org/packages/11/dc/e66551683ade663b5f07d7b3bc46434bf703491dbd22ee12d1f979ca828f/pycryptodomex-3.21.0.tar.gz",
+            "sha256": "222d0bd05381dd25c32dd6065c071ebf084212ab79bab4599ba9e6a3e0009e6c"
         },
         {
             "type": "file",
@@ -37,13 +37,14 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ca/1c/89ffc63a9605b583d5df2be791a27bc1a42b7c32bab68d3c8f2f73a98cd4/urllib3-2.2.2-py3-none-any.whl",
-            "sha256": "a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"
-        },
+            "url": "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl",
+            "sha256": "1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"
+        }
         {
             "type": "git",
             "url": "https://github.com/solsticegamestudios/steam",
-            "commit": "152af7be3c3fae3c5bc891cef3932deb8e93deb6"
+            "tag": "v1.6.1",
+            "commit": "c3f78074117691ef0ddf9a9020879eb5a426e090"
         }
     ]
 }

--- a/python3-vdf.json
+++ b/python3-vdf.json
@@ -9,7 +9,11 @@
             "type": "git",
             "url": "https://github.com/solsticegamestudios/vdf",
             "tag": "v4.0",
-            "commit": "fb88ea7e38a85476743f5601b0c80d5715034623"
+            "commit": "fb88ea7e38a85476743f5601b0c80d5715034623",
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^v([\\d.]+)$"
+            }
         }
     ]
 }

--- a/python3-vdf.json
+++ b/python3-vdf.json
@@ -8,7 +8,8 @@
         {
             "type": "git",
             "url": "https://github.com/solsticegamestudios/vdf",
-            "commit": "eaa7f089dcb622d4e80a3bbf7185fe6e5d969cf3"
+            "tag": "v4.0",
+            "commit": "fb88ea7e38a85476743f5601b0c80d5715034623"
         }
     ]
 }

--- a/python3-zstandard.json
+++ b/python3-zstandard.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/4d/70/1f883646641d7ad3944181549949d146fa19e286e892bc013f7ce1579e8f/zstandard-0.21.0.tar.gz",
-            "sha256": "f08e3a10d01a247877e4cb61a82a319ea746c356a3786558bed2481e6c405546"
+            "url": "https://files.pythonhosted.org/packages/ed/f6/2ac0287b442160a89d726b17a9184a4c615bb5237db763791a7fd16d9df1/zstandard-0.23.0.tar.gz",
+            "sha256": "b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09"
         }
     ]
 }

--- a/python3-zstandard.json
+++ b/python3-zstandard.json
@@ -8,7 +8,11 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/ed/f6/2ac0287b442160a89d726b17a9184a4c615bb5237db763791a7fd16d9df1/zstandard-0.23.0.tar.gz",
-            "sha256": "b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09"
+            "sha256": "b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "zstandard"
+            }
         }
     ]
 }


### PR DESCRIPTION
Adds data for [flatpak-external-data-checker](https://github.com/flathub-infra/flatpak-external-data-checker). It is configured to only raise PRs, when ProtonUp-Qt gets updated, but will include updates to the python modules in these PRs.

I don't know if you are interested in that, but thought it could help to maintain this flatpak.