### PR TITLE
Revert PySide6 to version 6.9

### DIFF
--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -1,10 +1,10 @@
 {
     "app-id": "net.davidotek.pupgui2",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.10",
+    "runtime-version": "6.9",
     "sdk": "org.kde.Sdk",
     "base": "io.qt.PySide.BaseApp",
-    "base-version": "6.10",
+    "base-version": "6.9",
     "command": "net.davidotek.pupgui2",
     "finish-args": [
         "--share=ipc",


### PR DESCRIPTION
See https://github.com/DavidoTek/ProtonUp-Qt/issues/601

ABI mismatch between 6.10.0 (PySide6 Base App) and 6.10.2 (KDE Runtime) prevents ProtonUp-Qt from launching. I assume we can revert to 6.10 once https://github.com/flathub/io.qt.PySide.BaseApp/pull/36 is merged.

- https://github.com/flathub/io.qt.PySide.BaseApp/pull/36
- https://invent.kde.org/packaging/flatpak-kde-runtime/-/merge_requests/345