### PR TITLE
Revert PySide6 to version 6.10 again

### DIFF
--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -1,10 +1,10 @@
 {
     "app-id": "net.davidotek.pupgui2",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.9",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "base": "io.qt.PySide.BaseApp",
-    "base-version": "6.9",
+    "base-version": "6.10",
     "command": "net.davidotek.pupgui2",
     "finish-args": [
         "--share=ipc",


### PR DESCRIPTION
See https://github.com/flathub/net.davidotek.pupgui2/pull/43 https://github.com/DavidoTek/ProtonUp-Qt/issues/601

Depends on https://github.com/flathub/io.qt.PySide.BaseApp/pull/36