### PR TITLE
Revert PySide6 to version 6.9 again

### DIFF
--- a/net.davidotek.pupgui2.json
+++ b/net.davidotek.pupgui2.json
@@ -1,10 +1,10 @@
 {
     "app-id": "net.davidotek.pupgui2",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.10",
+    "runtime-version": "6.9",
     "sdk": "org.kde.Sdk",
     "base": "io.qt.PySide.BaseApp",
-    "base-version": "6.10",
+    "base-version": "6.9",
     "command": "net.davidotek.pupgui2",
     "finish-args": [
         "--share=ipc",


### PR DESCRIPTION
See https://github.com/flathub/net.davidotek.pupgui2/issues/47

This was already done previously with https://github.com/flathub/net.davidotek.pupgui2/pull/43 and reverted with https://github.com/flathub/net.davidotek.pupgui2/pull/44. This PR changes the version back to 6.9 again.